### PR TITLE
update(laravel): Add support for laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "guzzlehttp/guzzle": "^7.5",
-        "illuminate/support": "^12.0"
+        "illuminate/support": "^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0",
-        "phpunit/phpunit": "^11.0"
+        "orchestra/testbench": "^11.0",
+        "phpunit/phpunit": "^12.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Bump `illuminate/support` constraint to `^13.0`
- Bump PHP requirement to `^8.3` (Laravel 13 floor)
- Bump `orchestra/testbench` to `^11.0` and `phpunit/phpunit` to `^12.0`

## Test plan
- [x] `composer update` resolves cleanly
- [x] `vendor/bin/phpunit` — 31 tests, 85 assertions, all green